### PR TITLE
feat: add GraphQL support

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -1,0 +1,365 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// GraphQLConfig holds configuration for the GraphQL test suite.
+type GraphQLConfig struct {
+	BaseURL string        // GraphQL endpoint URL
+	Timeout time.Duration // Default timeout for requests
+}
+
+// GraphQLSuite represents the GraphQL test suite.
+type GraphQLSuite struct {
+	config GraphQLConfig
+	t      testing.TB
+	client *http.Client
+}
+
+// GraphQLBuilder builds GraphQL requests.
+type GraphQLBuilder struct {
+	suite     *GraphQLSuite
+	query     string
+	variables map[string]any
+	headers   map[string]string
+	timeout   time.Duration
+
+	// Response
+	response *GraphQLResponse
+}
+
+// GraphQLResponse represents a GraphQL response.
+type GraphQLResponse struct {
+	Data   json.RawMessage `json:"data,omitempty"`
+	Errors []GraphQLError  `json:"errors,omitempty"`
+}
+
+// GraphQLError represents a GraphQL error.
+type GraphQLError struct {
+	Message   string `json:"message"`
+	Locations []struct {
+		Line   int `json:"line"`
+		Column int `json:"column"`
+	} `json:"locations,omitempty"`
+	Path []any `json:"path,omitempty"`
+}
+
+// NewGraphQL creates a new GraphQL test suite.
+func NewGraphQL(tb testing.TB, config GraphQLConfig) *GraphQLSuite {
+	tb.Helper()
+
+	if config.Timeout == 0 {
+		config.Timeout = 30 * time.Second
+	}
+
+	return &GraphQLSuite{
+		config: config,
+		t:      tb,
+		client: &http.Client{
+			Timeout: config.Timeout,
+		},
+	}
+}
+
+// Query creates a GraphQL query builder.
+func (s *GraphQLSuite) Query(query string) *GraphQLBuilder {
+	return &GraphQLBuilder{
+		suite: s,
+		query: query,
+	}
+}
+
+// Mutation creates a GraphQL mutation builder.
+func (s *GraphQLSuite) Mutation(mutation string) *GraphQLBuilder {
+	return &GraphQLBuilder{
+		suite: s,
+		query: mutation,
+	}
+}
+
+// Variables sets GraphQL variables.
+func (b *GraphQLBuilder) Variables(vars map[string]any) *GraphQLBuilder {
+	b.variables = vars
+
+	return b
+}
+
+// Header sets an HTTP header.
+func (b *GraphQLBuilder) Header(key, value string) *GraphQLBuilder {
+	if b.headers == nil {
+		b.headers = make(map[string]string)
+	}
+
+	b.headers[key] = value
+
+	return b
+}
+
+// Timeout sets request timeout.
+func (b *GraphQLBuilder) Timeout(d time.Duration) *GraphQLBuilder {
+	b.timeout = d
+
+	return b
+}
+
+// Execute performs the GraphQL request.
+func (b *GraphQLBuilder) Execute(ctx context.Context) *GraphQLBuilder {
+	if b.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, b.timeout)
+		b.suite.t.Cleanup(cancel)
+	}
+
+	// Build request body
+	reqBody := map[string]any{
+		"query": b.query,
+	}
+
+	if len(b.variables) > 0 {
+		reqBody["variables"] = b.variables
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		b.suite.t.Fatalf("Failed to marshal GraphQL request: %v", err)
+	}
+
+	// Create HTTP request
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, b.suite.config.BaseURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		b.suite.t.Fatalf("Failed to create request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	for key, value := range b.headers {
+		req.Header.Set(key, value)
+	}
+
+	// Execute request
+	client := b.suite.client
+	if b.timeout > 0 {
+		client = &http.Client{Timeout: b.timeout}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		b.suite.t.Fatalf("Failed to execute GraphQL request: %v", err)
+	}
+
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			b.suite.t.Logf("Failed to close response body: %v", closeErr)
+		}
+	}()
+
+	// Read response
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		b.suite.t.Fatalf("Failed to read response body: %v", err)
+	}
+
+	// Parse GraphQL response
+	var gqlResp GraphQLResponse
+	if err := json.Unmarshal(respBody, &gqlResp); err != nil {
+		b.suite.t.Fatalf("Failed to parse GraphQL response: %v. Body: %s", err, string(respBody))
+	}
+
+	b.response = &gqlResp
+
+	return b
+}
+
+// ExpectNoErrors validates no errors in response.
+func (b *GraphQLBuilder) ExpectNoErrors() *GraphQLBuilder {
+	if b.response == nil {
+		b.suite.t.Fatal("Request not executed. Call Execute() first.")
+	}
+
+	if len(b.response.Errors) > 0 {
+		var msgs []string
+		for _, e := range b.response.Errors {
+			msgs = append(msgs, e.Message)
+		}
+
+		b.suite.t.Fatal(b.formatError(
+			"Expected no GraphQL errors",
+			"no errors",
+			strings.Join(msgs, ", "),
+		))
+	}
+
+	return b
+}
+
+// ExpectErrors validates errors exist in response.
+func (b *GraphQLBuilder) ExpectErrors() *GraphQLBuilder {
+	if b.response == nil {
+		b.suite.t.Fatal("Request not executed. Call Execute() first.")
+	}
+
+	if len(b.response.Errors) == 0 {
+		b.suite.t.Fatal(b.formatError(
+			"Expected GraphQL errors",
+			"at least one error",
+			"no errors",
+		))
+	}
+
+	return b
+}
+
+// ExpectErrorMessage validates error message exists.
+func (b *GraphQLBuilder) ExpectErrorMessage(msg string) *GraphQLBuilder {
+	if b.response == nil {
+		b.suite.t.Fatal("Request not executed. Call Execute() first.")
+	}
+
+	for _, e := range b.response.Errors {
+		if e.Message == msg {
+			return b
+		}
+	}
+
+	msgs := make([]string, 0, len(b.response.Errors))
+	for _, e := range b.response.Errors {
+		msgs = append(msgs, e.Message)
+	}
+
+	b.suite.t.Fatal(b.formatError(
+		"Expected error message not found",
+		msg,
+		strings.Join(msgs, ", "),
+	))
+
+	return b
+}
+
+// ExpectData validates the entire data response.
+func (b *GraphQLBuilder) ExpectData(expected any) *GraphQLBuilder {
+	if b.response == nil {
+		b.suite.t.Fatal("Request not executed. Call Execute() first.")
+	}
+
+	// Marshal expected to JSON for comparison
+	expectedBytes, err := json.Marshal(expected)
+	if err != nil {
+		b.suite.t.Fatalf("Failed to marshal expected data: %v", err)
+	}
+
+	// Normalize both for comparison
+	var expectedNorm, actualNorm any
+	if err := json.Unmarshal(expectedBytes, &expectedNorm); err != nil {
+		b.suite.t.Fatalf("Failed to normalize expected data: %v", err)
+	}
+
+	if err := json.Unmarshal(b.response.Data, &actualNorm); err != nil {
+		b.suite.t.Fatalf("Failed to parse response data: %v", err)
+	}
+
+	if !jsonEqual(expectedNorm, actualNorm) {
+		expectedJSON, _ := json.MarshalIndent(expectedNorm, "", "  ")
+		actualJSON, _ := json.MarshalIndent(actualNorm, "", "  ")
+		b.suite.t.Fatal(b.formatError(
+			"GraphQL data mismatch",
+			string(expectedJSON),
+			string(actualJSON),
+		))
+	}
+
+	return b
+}
+
+// ExpectDataPath validates a specific path in data.
+func (b *GraphQLBuilder) ExpectDataPath(path string, expected any) *GraphQLBuilder {
+	if b.response == nil {
+		b.suite.t.Fatal("Request not executed. Call Execute() first.")
+	}
+
+	// Parse response data
+	var data map[string]any
+	if err := json.Unmarshal(b.response.Data, &data); err != nil {
+		b.suite.t.Fatalf("Failed to parse response data: %v", err)
+	}
+
+	// Navigate path
+	parts := strings.Split(path, ".")
+
+	var current any = data
+
+	for _, part := range parts {
+		switch v := current.(type) {
+		case map[string]any:
+			var ok bool
+			current, ok = v[part]
+
+			if !ok {
+				b.suite.t.Fatal(b.formatError(
+					fmt.Sprintf("Path %q not found at %q", path, part),
+					fmt.Sprintf("%v", expected),
+					"<missing>",
+				))
+			}
+		default:
+			b.suite.t.Fatalf("Cannot navigate path %q: unexpected type at %q", path, part)
+		}
+	}
+
+	// Compare values
+	if current != expected {
+		b.suite.t.Fatal(b.formatError(
+			fmt.Sprintf("Data at path %q mismatch", path),
+			fmt.Sprintf("%v", expected),
+			fmt.Sprintf("%v", current),
+		))
+	}
+
+	return b
+}
+
+// formatError creates a detailed error message.
+func (b *GraphQLBuilder) formatError(assertion, expected, actual string) string {
+	var sb bytes.Buffer
+
+	sb.WriteString("\n=== GraphQL Request Failed ===\n")
+	sb.WriteString(fmt.Sprintf("Endpoint: %s\n", b.suite.config.BaseURL))
+	sb.WriteString(fmt.Sprintf("Query:    %s\n", truncateString(b.query, 100)))
+
+	if len(b.variables) > 0 {
+		varsJSON, _ := json.Marshal(b.variables)
+		sb.WriteString(fmt.Sprintf("Vars:     %s\n", truncateString(string(varsJSON), 100)))
+	}
+
+	if b.response != nil && len(b.response.Errors) > 0 {
+		sb.WriteString("\nErrors:\n")
+
+		for _, e := range b.response.Errors {
+			sb.WriteString(fmt.Sprintf("  - %s\n", e.Message))
+		}
+	}
+
+	sb.WriteString("\n")
+	sb.WriteString(fmt.Sprintf("%s:\n", assertion))
+	sb.WriteString(fmt.Sprintf("Expected: %s\n", expected))
+	sb.WriteString(fmt.Sprintf("Actual:   %s\n", actual))
+
+	return sb.String()
+}
+
+// truncateString truncates a string if it exceeds the maximum length.
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+
+	return s[:maxLen] + "..."
+}

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -1,0 +1,113 @@
+package e2e_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sivchari/e2e"
+	"github.com/sivchari/e2e/test/e2e/graphql/testserver"
+)
+
+func TestGraphQL_NewGraphQL(t *testing.T) {
+	url := testserver.StartTestServer(t)
+
+	client := e2e.NewGraphQL(t, e2e.GraphQLConfig{
+		BaseURL: url,
+	})
+
+	if client == nil {
+		t.Fatal("Expected non-nil client")
+	}
+}
+
+func TestGraphQL_Query_Users(t *testing.T) {
+	url := testserver.StartTestServer(t)
+	client := e2e.NewGraphQL(t, e2e.GraphQLConfig{BaseURL: url})
+
+	client.Query(`query { users { id name } }`).
+		Execute(context.Background()).
+		ExpectNoErrors()
+}
+
+func TestGraphQL_Query_User(t *testing.T) {
+	url := testserver.StartTestServer(t)
+	client := e2e.NewGraphQL(t, e2e.GraphQLConfig{BaseURL: url})
+
+	client.Query(`query($id: ID!) { user(id: $id) { id name email } }`).
+		Variables(map[string]any{"id": "1"}).
+		Execute(context.Background()).
+		ExpectNoErrors().
+		ExpectData(map[string]any{
+			"user": map[string]any{
+				"id":    "1",
+				"name":  "Alice",
+				"email": "alice@example.com",
+			},
+		})
+}
+
+func TestGraphQL_Query_UserNotFound(t *testing.T) {
+	url := testserver.StartTestServer(t)
+	client := e2e.NewGraphQL(t, e2e.GraphQLConfig{BaseURL: url})
+
+	client.Query(`query($id: ID!) { user(id: $id) { id name } }`).
+		Variables(map[string]any{"id": "999"}).
+		Execute(context.Background()).
+		ExpectErrors().
+		ExpectErrorMessage("user not found")
+}
+
+func TestGraphQL_Mutation_CreateUser(t *testing.T) {
+	url := testserver.StartTestServer(t)
+	client := e2e.NewGraphQL(t, e2e.GraphQLConfig{BaseURL: url})
+
+	client.Mutation(`mutation($input: CreateUserInput!) { createUser(input: $input) { id name email } }`).
+		Variables(map[string]any{
+			"input": map[string]any{
+				"name":  "Charlie",
+				"email": "charlie@example.com",
+			},
+		}).
+		Execute(context.Background()).
+		ExpectNoErrors().
+		ExpectData(map[string]any{
+			"createUser": map[string]any{
+				"id":    "3",
+				"name":  "Charlie",
+				"email": "charlie@example.com",
+			},
+		})
+}
+
+func TestGraphQL_Header(t *testing.T) {
+	url := testserver.StartTestServer(t)
+	client := e2e.NewGraphQL(t, e2e.GraphQLConfig{BaseURL: url})
+
+	client.Query(`query($message: String!) { echo(message: $message) { message authorization } }`).
+		Variables(map[string]any{"message": "hello"}).
+		Header("Authorization", "Bearer test-token").
+		Execute(context.Background()).
+		ExpectNoErrors().
+		ExpectDataPath("echo.authorization", "Bearer test-token")
+}
+
+func TestGraphQL_Timeout(t *testing.T) {
+	url := testserver.StartTestServer(t)
+	client := e2e.NewGraphQL(t, e2e.GraphQLConfig{BaseURL: url})
+
+	client.Query(`query { users { id } }`).
+		Timeout(5 * time.Second).
+		Execute(context.Background()).
+		ExpectNoErrors()
+}
+
+func TestGraphQL_MultipleErrors(t *testing.T) {
+	url := testserver.StartTestServer(t)
+	client := e2e.NewGraphQL(t, e2e.GraphQLConfig{BaseURL: url})
+
+	client.Query(`query { error }`).
+		Execute(context.Background()).
+		ExpectErrors().
+		ExpectErrorMessage("Something went wrong")
+}

--- a/test/e2e/error_message_test.go
+++ b/test/e2e/error_message_test.go
@@ -1,0 +1,196 @@
+package e2e_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sivchari/e2e"
+)
+
+// mockT is a mock testing.TB to capture fatal messages.
+type mockT struct {
+	testing.TB
+	fatalMsg string
+}
+
+func (m *mockT) Fatal(args ...interface{}) {
+	if len(args) > 0 {
+		if msg, ok := args[0].(string); ok {
+			m.fatalMsg = msg
+		}
+	}
+
+	panic("fatal called")
+}
+
+func (m *mockT) Fatalf(format string, _ ...interface{}) {
+	m.fatalMsg = format
+
+	panic("fatal called")
+}
+
+func (m *mockT) Helper() {}
+
+func (m *mockT) Cleanup(_ func()) {}
+
+func (m *mockT) Logf(_ string, _ ...interface{}) {}
+
+func TestErrorMessageContainsRequestDetails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"validation failed"}`))
+	}))
+	defer server.Close()
+
+	mt := &mockT{TB: t}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Expected panic from Fatal call")
+		}
+
+		// Verify error message contains key information
+		if !strings.Contains(mt.fatalMsg, "=== HTTP Request Failed ===") {
+			t.Errorf("Error message should contain header, got: %s", mt.fatalMsg)
+		}
+
+		if !strings.Contains(mt.fatalMsg, "POST /api/users") {
+			t.Errorf("Error message should contain request method and path, got: %s", mt.fatalMsg)
+		}
+
+		if !strings.Contains(mt.fatalMsg, "URL:") {
+			t.Errorf("Error message should contain URL, got: %s", mt.fatalMsg)
+		}
+
+		if !strings.Contains(mt.fatalMsg, "Response: 400 Bad Request") {
+			t.Errorf("Error message should contain response status, got: %s", mt.fatalMsg)
+		}
+
+		if !strings.Contains(mt.fatalMsg, "Expected: 201 Created") {
+			t.Errorf("Error message should contain expected status, got: %s", mt.fatalMsg)
+		}
+
+		if !strings.Contains(mt.fatalMsg, "Actual:") || !strings.Contains(mt.fatalMsg, "400 Bad Request") {
+			t.Errorf("Error message should contain actual status, got: %s", mt.fatalMsg)
+		}
+	}()
+
+	client := e2e.New(mt, e2e.Config{BaseURL: server.URL})
+	client.POST("/api/users").
+		Body(map[string]string{"name": "Alice"}).
+		Execute(context.Background()).
+		ExpectStatus(http.StatusCreated)
+}
+
+func TestErrorMessageContainsRequestBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	mt := &mockT{TB: t}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Expected panic from Fatal call")
+		}
+
+		if !strings.Contains(mt.fatalMsg, `"name":"Alice"`) {
+			t.Errorf("Error message should contain request body, got: %s", mt.fatalMsg)
+		}
+	}()
+
+	client := e2e.New(mt, e2e.Config{BaseURL: server.URL})
+	client.POST("/api/users").
+		Body(map[string]string{"name": "Alice"}).
+		Execute(context.Background()).
+		ExpectStatus(http.StatusCreated)
+}
+
+func TestErrorMessageContainsRequestHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	mt := &mockT{TB: t}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Expected panic from Fatal call")
+		}
+
+		if !strings.Contains(mt.fatalMsg, "Authorization: Bearer token123") {
+			t.Errorf("Error message should contain request headers, got: %s", mt.fatalMsg)
+		}
+	}()
+
+	client := e2e.New(mt, e2e.Config{BaseURL: server.URL})
+	client.GET("/api/users").
+		Authorization("Bearer token123").
+		Execute(context.Background()).
+		ExpectStatus(http.StatusOK)
+}
+
+func TestErrorMessageContainsResponseBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid email format"}`))
+	}))
+	defer server.Close()
+
+	mt := &mockT{TB: t}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Expected panic from Fatal call")
+		}
+
+		if !strings.Contains(mt.fatalMsg, "invalid email format") {
+			t.Errorf("Error message should contain response body, got: %s", mt.fatalMsg)
+		}
+	}()
+
+	client := e2e.New(mt, e2e.Config{BaseURL: server.URL})
+	client.POST("/api/users").
+		Execute(context.Background()).
+		ExpectStatus(http.StatusCreated)
+}
+
+func TestErrorMessageHeaderMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Custom-Header", "wrong-value")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	mt := &mockT{TB: t}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Expected panic from Fatal call")
+		}
+
+		if !strings.Contains(mt.fatalMsg, "Header mismatch (X-Custom-Header)") {
+			t.Errorf("Error message should contain header mismatch info, got: %s", mt.fatalMsg)
+		}
+
+		if !strings.Contains(mt.fatalMsg, "Expected: expected-value") {
+			t.Errorf("Error message should contain expected header value, got: %s", mt.fatalMsg)
+		}
+
+		if !strings.Contains(mt.fatalMsg, "Actual:") || !strings.Contains(mt.fatalMsg, "wrong-value") {
+			t.Errorf("Error message should contain actual header value, got: %s", mt.fatalMsg)
+		}
+	}()
+
+	client := e2e.New(mt, e2e.Config{BaseURL: server.URL})
+	client.GET("/").
+		Execute(context.Background()).
+		ExpectHeader("X-Custom-Header", "expected-value")
+}

--- a/test/e2e/graphql/testserver/server.go
+++ b/test/e2e/graphql/testserver/server.go
@@ -1,0 +1,191 @@
+// Package testserver provides a GraphQL server for testing.
+package testserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// User represents a user in the test data.
+type User struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+// GraphQLRequest represents a GraphQL request.
+type GraphQLRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables,omitempty"`
+}
+
+// GraphQLResponse represents a GraphQL response.
+type GraphQLResponse struct {
+	Data   any            `json:"data,omitempty"`
+	Errors []GraphQLError `json:"errors,omitempty"`
+}
+
+// GraphQLError represents a GraphQL error.
+type GraphQLError struct {
+	Message string `json:"message"`
+}
+
+// Server implements a simple GraphQL server for testing.
+type Server struct {
+	users map[string]*User
+}
+
+// NewServer creates a new test server.
+func NewServer() *Server {
+	return &Server{
+		users: map[string]*User{
+			"1": {ID: "1", Name: "Alice", Email: "alice@example.com"},
+			"2": {ID: "2", Name: "Bob", Email: "bob@example.com"},
+		},
+	}
+}
+
+// ServeHTTP handles GraphQL requests.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+
+		return
+	}
+
+	var req GraphQLRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeError(w, "Invalid request body")
+
+		return
+	}
+
+	resp := s.handleQuery(req, r.Header)
+	w.Header().Set("Content-Type", "application/json")
+
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+func (s *Server) handleQuery(req GraphQLRequest, headers http.Header) GraphQLResponse {
+	query := strings.TrimSpace(req.Query)
+
+	// Simple query parsing for testing
+	switch {
+	case strings.Contains(query, "users"):
+		return s.handleUsersQuery()
+	case strings.Contains(query, "user("):
+		return s.handleUserQuery(req.Variables)
+	case strings.Contains(query, "createUser"):
+		return s.handleCreateUser(req.Variables)
+	case strings.Contains(query, "echo"):
+		return s.handleEcho(req.Variables, headers)
+	case strings.Contains(query, "error"):
+		return s.handleError()
+	default:
+		return GraphQLResponse{
+			Errors: []GraphQLError{{Message: "Unknown query"}},
+		}
+	}
+}
+
+func (s *Server) handleUsersQuery() GraphQLResponse {
+	users := make([]*User, 0, len(s.users))
+	for _, u := range s.users {
+		users = append(users, u)
+	}
+
+	return GraphQLResponse{
+		Data: map[string]any{"users": users},
+	}
+}
+
+func (s *Server) handleUserQuery(vars map[string]any) GraphQLResponse {
+	id, ok := vars["id"].(string)
+	if !ok {
+		return GraphQLResponse{
+			Errors: []GraphQLError{{Message: "id is required"}},
+		}
+	}
+
+	user, exists := s.users[id]
+	if !exists {
+		return GraphQLResponse{
+			Errors: []GraphQLError{{Message: "user not found"}},
+		}
+	}
+
+	return GraphQLResponse{
+		Data: map[string]any{"user": user},
+	}
+}
+
+func (s *Server) handleCreateUser(vars map[string]any) GraphQLResponse {
+	input, ok := vars["input"].(map[string]any)
+	if !ok {
+		return GraphQLResponse{
+			Errors: []GraphQLError{{Message: "input is required"}},
+		}
+	}
+
+	name, _ := input["name"].(string)
+	email, _ := input["email"].(string)
+
+	user := &User{
+		ID:    "3",
+		Name:  name,
+		Email: email,
+	}
+
+	return GraphQLResponse{
+		Data: map[string]any{"createUser": user},
+	}
+}
+
+func (s *Server) handleEcho(vars map[string]any, headers http.Header) GraphQLResponse {
+	msg, _ := vars["message"].(string)
+
+	return GraphQLResponse{
+		Data: map[string]any{
+			"echo": map[string]any{
+				"message":       msg,
+				"authorization": headers.Get("Authorization"),
+			},
+		},
+	}
+}
+
+func (s *Server) handleError() GraphQLResponse {
+	return GraphQLResponse{
+		Errors: []GraphQLError{
+			{Message: "Something went wrong"},
+			{Message: "Another error"},
+		},
+	}
+}
+
+func (s *Server) writeError(w http.ResponseWriter, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+
+	resp := GraphQLResponse{
+		Errors: []GraphQLError{{Message: msg}},
+	}
+
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+// StartTestServer starts a GraphQL server for testing and returns the URL.
+func StartTestServer(t *testing.T) string {
+	t.Helper()
+
+	srv := httptest.NewServer(NewServer())
+	t.Cleanup(srv.Close)
+
+	return srv.URL
+}


### PR DESCRIPTION
## Summary

- GraphQL テスト機能を追加
- HTTP API と一貫したメソッドチェーン API を提供
- Query/Mutation の完全サポート

## 新機能

- `NewGraphQL(t, GraphQLConfig)` - GraphQL テストスイート作成
- `Query(query)` - GraphQL クエリ実行
- `Mutation(mutation)` - GraphQL ミューテーション実行
- `Variables(map[string]any)` - 変数設定
- `Header(key, value)` - HTTP ヘッダー設定
- `Timeout(duration)` - タイムアウト設定
- `Execute(ctx)` - リクエスト実行
- `ExpectNoErrors()` - エラーなし検証
- `ExpectErrors()` - エラーあり検証
- `ExpectErrorMessage(msg)` - エラーメッセージ検証
- `ExpectData(expected)` - データ全体検証
- `ExpectDataPath(path, value)` - パス指定検証

## 使用例

```go
client := e2e.NewGraphQL(t, e2e.GraphQLConfig{BaseURL: "http://localhost:8080/graphql"})

// Query
client.Query(\`query($id: ID!) { user(id: $id) { name } }\`).
    Variables(map[string]any{"id": "1"}).
    Execute(context.Background()).
    ExpectNoErrors().
    ExpectDataPath("user.name", "Alice")

// Mutation
client.Mutation(\`mutation($input: CreateUserInput!) { createUser(input: $input) { id } }\`).
    Variables(map[string]any{"input": map[string]any{"name": "Bob"}}).
    Execute(context.Background()).
    ExpectNoErrors()
```

## Test plan

- [x] NewGraphQL 初期化テスト
- [x] Query Users テスト
- [x] Query User テスト
- [x] Query UserNotFound エラーテスト
- [x] Mutation CreateUser テスト
- [x] Header 設定テスト
- [x] Timeout 設定テスト
- [x] MultipleErrors テスト
- [x] golangci-lint パス